### PR TITLE
Fixed Argument #1 ($preserve) must be of type string, null given, called in /app/web/themes/custom/custom/civictheme/modules/civictheme_govcms/src/Commands/CivicthemeGovcmsCommands.php

### DIFF
--- a/src/Commands/CivicthemeGovcmsCommands.php
+++ b/src/Commands/CivicthemeGovcmsCommands.php
@@ -47,7 +47,7 @@ class CivicthemeGovcmsCommands extends DrushCommands {
    * - pathauto_patterns
    */
   public function drushCivicthemeGovcmsRemoveConfig(array $options = ['preserve' => NULL]): void {
-    $options += ['preserve' => ''];
+    $preserve = (string) ($options['preserve'] ?? '');
 
     // Removing configs will lead to showing warnings about missing bundles,
     // which are only shown due to dependencies resolution concurrency issues.
@@ -56,7 +56,7 @@ class CivicthemeGovcmsCommands extends DrushCommands {
     $current = $this->output()->getVerbosity();
     $this->output()->setVerbosity(OutputInterface::VERBOSITY_QUIET);
 
-    $this->govcmsManager->civicthemeGovcmsRemoveConfig($options['preserve']);
+    $this->govcmsManager->civicthemeGovcmsRemoveConfig($preserve);
 
     $this->output()->setVerbosity($current);
   }


### PR DESCRIPTION
**Issue**

Argument #1 ($preserve) must be of type string, null given, called in /app/web/themes/custom/custom/civictheme/modules/civictheme_govcms/src/Commands/CivicthemeGovcmsCommands.php

![Screenshot 2025-07-09 at 7 58 24 PM](https://github.com/user-attachments/assets/3c8faa6f-6a60-4aea-9197-955772746ce1)
